### PR TITLE
Stop building wallpapers

### DIFF
--- a/target/product/full_base.mk
+++ b/target/product/full_base.mk
@@ -28,14 +28,7 @@ PRODUCT_PACKAGES := \
     WAPPushManager
 
 PRODUCT_PACKAGES += \
-    Galaxy4 \
-    HoloSpiralWallpaper \
-    LiveWallpapers \
-    LiveWallpapersPicker \
-    MagicSmokeWallpapers \
-    NoiseField \
-    PhaseBeam \
-    PhotoTable
+    LiveWallpapersPicker
 
 # Additional settings used in all AOSP builds
 PRODUCT_PROPERTY_OVERRIDES := \


### PR DESCRIPTION
Our devices can't properly handle them and they are just a waste of resources.
Keep the livewallpaperpicker so people can still install and select live wallpapers if they want to.
